### PR TITLE
subscriptions-graphql-ws: proper shutdown

### DIFF
--- a/apollo-server/v3/subscriptions-graphql-ws/package.json
+++ b/apollo-server/v3/subscriptions-graphql-ws/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@graphql-tools/schema": "^7.1.5",
     "@types/ws": "^8.2.2",
+    "apollo-server-core": "3.6.2",
     "apollo-server-express": "3.6.2",
     "express": "^4.17.1",
     "graphql": "^15.5.1",

--- a/apollo-server/v3/subscriptions-graphql-ws/yarn.lock
+++ b/apollo-server/v3/subscriptions-graphql-ws/yarn.lock
@@ -272,7 +272,7 @@ apollo-server-caching@^3.3.0:
   dependencies:
     lru-cache "^6.0.0"
 
-apollo-server-core@^3.6.2:
+apollo-server-core@3.6.2, apollo-server-core@^3.6.2:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/apollo-server-core/-/apollo-server-core-3.6.2.tgz#d9cbc3d0ba928d86a24640a485f4601b89b485fd"
   integrity sha512-GNx41BnpH/yvGv7nTt4bQXuH5BDVs9CBQawfOcgtVdoVoWkazv1Dwy1muqPa7WDt2rk9oY+P6QymtJpBAtmzhg==


### PR DESCRIPTION
The original version of this example didn't even use the HTTP draining
plugin, let alone shutting down the websocket server properly.