### PR TITLE
fix issues with AS4 generated-types example

### DIFF
--- a/apollo-server/v4/generated-types/src/datasources.ts
+++ b/apollo-server/v4/generated-types/src/datasources.ts
@@ -1,37 +1,44 @@
 // Use our automatically generated Book and AddBookMutationResponse types
 // for type safety in our data source class
-import { AddBookMutationResponse, Book } from './__generated__/resolvers-types';
+import { AddBookMutationResponse, Book } from "./__generated__/resolvers-types";
+
+const BooksDB: Omit<Required<Book>, "__typename">[] = [
+  {
+    title: "The Awakening",
+    author: "Kate Chopin",
+  },
+  {
+    title: "City of Glass",
+    author: "Paul Auster",
+  },
+];
 
 export class BooksDataSource {
-  // Our example static data set
-  books: { title?: string; author?: string }[] = [
-    {
-      title: 'The Awakening',
-      author: 'Kate Chopin',
-    },
-    {
-      title: 'City of Glass',
-      author: 'Paul Auster',
-    },
-  ];
-
   getBooks(): Book[] {
     // simulate fetching a list of books
-    return this.books;
+    return BooksDB;
   }
 
   // We are using a static data set for this small example, but normally
   // this Mutation would *mutate* our underlying data using a database
   // or a REST API.
   async addBook(book: Book): Promise<AddBookMutationResponse> {
-    this.books.push(book);
-    console.log(this.books);
+    if (book.title && book.author) {
+      BooksDB.push({ title: book.title, author: book.author });
 
-    return {
-      code: '200',
-      success: true,
-      message: 'New book added!',
-      book: this.books[this.books.length - 1],
-    };
+      return {
+        code: "200",
+        success: true,
+        message: "New book added!",
+        book,
+      };
+    } else {
+      return {
+        code: "400",
+        success: false,
+        message: "Invalid input",
+        book: null,
+      };
+    }
   }
 }

--- a/apollo-server/v4/generated-types/src/index.ts
+++ b/apollo-server/v4/generated-types/src/index.ts
@@ -1,15 +1,12 @@
-import { ApolloServer } from '@apollo/server';
-import { startStandaloneServer } from '@apollo/server/standalone';
-import { BooksDataSource } from './datasources.js';
-// Here we import the automatically generated Book type, so we can use it in our
-// context typing.
-import { Book } from './__generated__/resolvers-types';
-import resolvers from './resolvers/index.js';
-import { readFileSync } from 'fs';
+import { ApolloServer } from "@apollo/server";
+import { startStandaloneServer } from "@apollo/server/standalone";
+import { BooksDataSource } from "./datasources.js";
+import resolvers from "./resolvers/index.js";
+import { readFileSync } from "fs";
 
 // Note: this only works locally because it relies on `npm` routing
 // from the root directory of the project.
-const typeDefs = readFileSync('./schema.graphql', { encoding: 'utf-8' });
+const typeDefs = readFileSync("./schema.graphql", { encoding: "utf-8" });
 
 export interface MyContext {
   dataSources: {

--- a/apollo-server/v4/generated-types/src/resolvers/index.ts
+++ b/apollo-server/v4/generated-types/src/resolvers/index.ts
@@ -1,11 +1,11 @@
-import { Resolvers } from '../__generated__/resolvers-types';
-import queries from './queries.js';
-import mutations from './mutations.js';
+import { Resolvers } from "../__generated__/resolvers-types";
+import Query from "./queries.js";
+import Mutation from "./mutations.js";
 
 // Note this "Resolvers" type isn't strictly necessary because we are already
 // separately type checking our queries and resolvers. However, the "Resolvers"
 // generated types is useful syntax if you are defining your resolvers
 // in a single file.
-const resolvers: Resolvers = { ...queries, ...mutations };
+const resolvers: Resolvers = { Query, Mutation };
 
 export default resolvers;

--- a/apollo-server/v4/generated-types/src/resolvers/mutations.ts
+++ b/apollo-server/v4/generated-types/src/resolvers/mutations.ts
@@ -1,13 +1,11 @@
-import { MutationResolvers } from '__generated__/resolvers-types';
+import { MutationResolvers } from "__generated__/resolvers-types";
 
 // Use the generated `MutationResolvers` type to type check our mutations!
 const mutations: MutationResolvers = {
-  Mutation: {
-    // Below, we mock adding a new book. Our data set is static for this
-    // example, so we won't actually modify our data.
-    addBook: async (_, { title, author }, { dataSources }) => {
-      return await dataSources.booksAPI.addBook({ title, author });
-    },
+  // Below, we mock adding a new book. Our data set is static for this
+  // example, so we won't actually modify our data.
+  addBook: async (_, { title, author }, { dataSources }) => {
+    return dataSources.booksAPI.addBook({ title, author });
   },
 };
 

--- a/apollo-server/v4/generated-types/src/resolvers/queries.ts
+++ b/apollo-server/v4/generated-types/src/resolvers/queries.ts
@@ -1,13 +1,11 @@
-import { QueryResolvers } from '__generated__/resolvers-types';
+import { QueryResolvers } from "__generated__/resolvers-types";
 
 // Use the generated `QueryResolvers` type to type check our queries!
 const queries: QueryResolvers = {
-  Query: {
-    // Our third argument (`contextValue`) has a type here, so we
-    // can check the properties within our resolver's shared context value.
-    books: async (_, __, contextValue) => {
-      return await contextValue.dataSources.booksAPI.getBooks();
-    },
+  // Our third argument (`contextValue`) has a type here, so we
+  // can check the properties within our resolver's shared context value.
+  books: async (_, __, { dataSources }) => {
+    return dataSources.booksAPI.getBooks();
   },
 };
 


### PR DESCRIPTION
* The query and mutation types were nested incorrectly. Everything was typed as `any`.
* The data source recreated the fixtures with every request so the mutation had no effect