### PR TITLE
chore: update renovate config to create separate server/client/gateway PRs

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -22,6 +22,13 @@
       ],
       "assignees": ["trevor-scheer"],
       "labels": ["apollo-server"]
+    },
+    {
+      "paths": [
+        "apollo-gateway/**",
+      ],
+      "assignees": ["smyrick"],
+      "labels": ["apollo-gateway"]
     }
   ],
     // Keep Apollo Server examples on the right major version.

--- a/renovate.json5
+++ b/renovate.json5
@@ -3,8 +3,27 @@
     "config:base"
   ],
   rangeStrategy: "bump",
+  "additionalBranchPrefix": "{{parentDir}}-",
   dependencyDashboard: true,
   packageRules: [
+  "packageRules": [
+    {
+      "paths": [
+        "apollo-client/**",
+        "full-stack/todo-list/todo-list-client/**"
+      ],
+      "assignees": ["alessbell"],
+      "labels": ["apollo-client"]
+    },
+    {
+      "paths": [
+        "apollo-server/**",
+        "full-stack/todo-list/todo-list-server/**"
+      ],
+      "assignees": ["trevor-scheer"],
+      "labels": ["apollo-server"]
+    }
+  ],
     // Keep Apollo Server examples on the right major version.
     {
       matchPaths: ["apollo-server/v2/**"],


### PR DESCRIPTION
@trevor-scheer I thought I'd update the renovate config here to separate out client/server upgrades so we don't have to worry about breaking each others' sandboxes by merging big PRs. Would you like me to assign anyone (I put your username for now 😀) to the server PRs? From what I can see in the docs/Stack Overflow it needs to be a username and not a GitHub team.

I'd eventually like to run the few tests that exist and auto-merge since I don't want to think about this repo, but also don't want it to fall a minor+ version behind the latest release of Apollo Client as has happened since I last updated these examples...